### PR TITLE
When waiting for coverage summary file, create a blank file to watch

### DIFF
--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -36,6 +36,7 @@ function watch() {
 
 fs.__addMockFile = __addMockFile;
 fs.__resetMockFiles = __resetMockFiles;
+fs.existsSync = function() { return false; };
 fs.readFileSync = readFileSync;
 fs.watch = watch;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { readFileSync, watch } from 'fs';
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, watch } from 'fs';
 
 import { getLastError } from './errors';
 import {
@@ -33,6 +33,13 @@ function onRunComplete(globalConfig: Config, options: RatchetOptions) {
     const coverageDirectory = findCoveragePath(globalConfig);
     const coverageSummaryPath = findCoverageSummaryPath(coverageDirectory);
     const jestConfigPath = findJestConfigPath(process.cwd(), process.argv);
+
+    if (!existsSync(coverageDirectory)) {
+      mkdirSync(coverageDirectory);
+    }
+    if (!existsSync(coverageSummaryPath)) {
+      closeSync(openSync(coverageSummaryPath, 'w'));
+    }
 
     const watcher = watch(coverageDirectory);
     watcher.once('change', () => {

--- a/src/test.ts
+++ b/src/test.ts
@@ -161,6 +161,7 @@ describe('jest-ratchet', () => {
       /\/jestconfig\.json$/,
       JSON.stringify({ ...threshold }),
     );
+    fs.existsSync = () => true;
 
     const jestRatchet = new JestRatchet({ ...mockConfig, ...threshold });
     jestRatchet.onRunComplete();


### PR DESCRIPTION
As the title says, this will create a blank file if the coverage summary file doesn't exist at run time.  Most of Jest-Ratchet needs to wait until this file exists and is up to date before it can proceed.