### PR TITLE
Add option to disable jest-ratchet

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, watch } from 'fs';
+import parser from 'yargs-parser';
 
 import { getLastError } from './errors';
 import {
@@ -12,18 +13,22 @@ import {
   findCoverageSummaryPath,
   findJestConfigPath,
 } from './locations';
+import { noop } from './noop';
 import { ratchetCoverage } from './ratchet';
 
 export default class JestRatchet {
-  public getLastError: () => void;
-  public onRunComplete: () => void;
+  public getLastError: () => void = noop;
+  public onRunComplete: () => void = noop;
 
   constructor(
     globalConfig: Config,
     options: RatchetOptions = {},
   ) {
-    this.onRunComplete = onRunComplete.bind(this, globalConfig, options);
-    this.getLastError = getLastError.bind(this, globalConfig);
+    const args = parser(process.argv.slice(2));
+    if (!args.disableRatchet) {
+      this.onRunComplete = onRunComplete.bind(this, globalConfig, options);
+      this.getLastError = getLastError.bind(this, globalConfig);
+    }
   }
 }
 

--- a/src/noop.ts
+++ b/src/noop.ts
@@ -1,0 +1,3 @@
+export function noop() {
+  // do nothing
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -3,6 +3,7 @@ jest.mock('fs');
 import _fs from 'fs';
 import { resolve } from 'path';
 import JestRatchet from './index';
+import { noop } from './noop';
 
 const fs = _fs as typeof _fs & {
   __addMockFile: (name: RegExp, value: string) => void;
@@ -14,11 +15,14 @@ const mockConfig = {
   coverageReporters: ['json-summary'],
 };
 
+const originalArgv = process.argv;
+
 describe('jest-ratchet', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     fs.__resetMockFiles();
     process.cwd = jest.fn().mockReturnValue(resolve('./example'));
+    process.argv = originalArgv;
   });
 
   it('will initialize without error', () => {
@@ -48,6 +52,14 @@ describe('jest-ratchet', () => {
 
     const jestRatchet = new JestRatchet(mockConfig);
     jestRatchet.onRunComplete();
+  });
+
+  it('will do nothing when ratchet is disabled', () => {
+    process.argv = ['', '', '--disable-ratchet'];
+
+    const jestRatchet = new JestRatchet(mockConfig);
+
+    expect(jestRatchet.onRunComplete).toBe(noop);
   });
 
   it('will ratchet percentages', () => {


### PR DESCRIPTION
This will address #22 and add an option to disable jest-ratchet via `--disable-ratchet` and allow build systems to skip the ratchet step of reporting coverage.