### PR TITLE
Add option to round down threshold percentages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ tags
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 .idea/
+*.iml
 
 # User-specific stuff:
 .idea/workspace.xml

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "testRegex": "test\\.ts$",
+    "testURL": "http://localhost/",
     "moduleFileExtensions": [
       "js",
       "ts",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -40,7 +40,7 @@ export interface RatchetOptions {
   timeout?: number;
 
   /** Round percentage thresholds down to the nearest percentage. */
-  roundPct?: boolean;
+  floorPct?: boolean;
 }
 
 export interface Config {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -38,6 +38,9 @@ export interface RatchetOptions {
 
   /** After set period timeout waiting for changes. Default: wait forever */
   timeout?: number;
+
+  /** Round percentage thresholds down to the nearest percentage. */
+  roundPct?: boolean;
 }
 
 export interface Config {

--- a/src/ratchet.ts
+++ b/src/ratchet.ts
@@ -44,7 +44,7 @@ function ratchetSingleNumberCoverage(
       ? Math.round(category.pct) - options.ratchetPercentagePadding
       : category.pct;
     if (num > 0 && num <= ratchetPct) {
-      return ratchetPct;
+      return options.roundPct ? Math.floor(ratchetPct) : ratchetPct;
     } else if (num < 0 && num >= -category.covered) {
       return -category.covered;
     }

--- a/src/ratchet.ts
+++ b/src/ratchet.ts
@@ -44,7 +44,7 @@ function ratchetSingleNumberCoverage(
       ? Math.round(category.pct) - options.ratchetPercentagePadding
       : category.pct;
     if (num > 0 && num <= ratchetPct) {
-      return options.roundPct ? Math.floor(ratchetPct) : ratchetPct;
+      return options.floorPct ? Math.floor(ratchetPct) : ratchetPct;
     } else if (num < 0 && num >= -category.covered) {
       return -category.covered;
     }

--- a/src/test.ts
+++ b/src/test.ts
@@ -146,7 +146,7 @@ describe('jest-ratchet', () => {
       ...threshold,
       rootDir: './example',
     }, {
-      roundPct: true,
+      floorPct: true,
     });
     jestRatchet.onRunComplete();
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -114,6 +114,55 @@ describe('jest-ratchet', () => {
         }));
   });
 
+  it('will round down percentages', () => {
+    const threshold = {
+      coverageThreshold: {
+        global: {
+          branches: 50,
+          functions: 50,
+          lines: 50,
+          statements: 50,
+        },
+      },
+    };
+    fs.__addMockFile(
+      /\/coverage-summary\.json$/,
+      JSON.stringify({
+        total: {
+          branches: {pct: 98.7},
+          functions: {pct: 51.3},
+          lines: {pct: 70.6},
+          statements: {pct: 75.8},
+        },
+      }),
+    );
+    fs.__addMockFile(
+      /\/package\.json$/,
+      JSON.stringify({ ...threshold }),
+    );
+
+    const jestRatchet = new JestRatchet({
+      ...mockConfig,
+      ...threshold,
+      rootDir: './example',
+    }, {
+      roundPct: true,
+    });
+    jestRatchet.onRunComplete();
+
+    const writeFileSync = fs.writeFileSync as jest.Mock;
+    expect(writeFileSync).toHaveBeenCalledWith(expect.anything(), JSON.stringify({
+      coverageThreshold: {
+        global: {
+          branches: 98,
+          functions: 51,
+          lines: 70,
+          statements: 75,
+        },
+      },
+    }), expect.anything());
+  });
+
   it('will pad the ratchet percentages', () => {
     const PADDING = 2;
     const threshold = {


### PR DESCRIPTION
I would like to add an option to allow jest-ratchet to save thresholds as whole percentages.