### PR TITLE
Update readme with minimum coverage reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add `jest-ratchet` to the `reporters` section. And also ensure that `collectCove
 ```json
 {
   "collectCoverage": true,
-  "coverageReporters": ["json", "lcov", "text", "clover", "json-summary"],
+  "coverageReporters": ["json-summary"],
   "reporters": ["default", "jest-ratchet"]
 }
 ```
@@ -50,7 +50,7 @@ Here's how to pass configuration to Jest-Ratchet, per the [Jest documentation](h
 ```json
 {
   "collectCoverage": true,
-  "coverageReporters": ["json", "lcov", "text", "clover", "json-summary"],
+  "coverageReporters": ["json-summary"],
   "reporters": [
     "default",
     [


### PR DESCRIPTION
@pmcelhaney, I just noticed that with https://github.com/markis/jest-ratchet/commit/853ba2fe024ec9bd75fbe61c295d308e8520e338, the documentation was updated to include more `coverageReporters` than are necessary. Was this intentional, or accidental copy-paste?