### PR TITLE
Refactor option naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ Add `jest-ratchet` to the `reporters` section. And also ensure that `collectCove
 
 By default, Jest-Ratchet is aggressive with updating coverage thresholds. Every time your coverage ticks up by 0.01%, the coverageThreshold is updated. There are a couple of options dampen this behavior.
 
-- ratchetPercentagePadding (number): keeps the threshold below the measured coverage, allowing wiggle room
-- floorPct (boolean): round down to the nearest integer
-
-There's also a _timeout (number)_ option, the number of milliseconds to wait for changes. The default is to wait forever.
+- tolerance (number): keeps the threshold below the measured coverage, allowing wiggle room. default: 0 tolerance
+- roundDown (boolean): round down to the nearest integer. default: false
+- timeout (number): the number of milliseconds to wait for to the Jest coverage json summary. default: wait indefinitely
 
 Here's how to pass configuration to Jest-Ratchet, per the [Jest documentation](https://jestjs.io/docs/en/configuration.html#reporters-array-modulename-modulename-options)
 
@@ -55,7 +54,7 @@ Here's how to pass configuration to Jest-Ratchet, per the [Jest documentation](h
     "default",
     [
       "jest-ratchet",
-      { "ratchetPercentagePadding": 2, "floorPct": true, "timeout": 5000 }
+      { "tolerance": 2, "roundDown": true, "timeout": 5000 }
     ]
   ]
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -33,14 +33,14 @@ export interface JestCoverageCategory {
 }
 
 export interface RatchetOptions {
-  /** Pad the ratchet percentage by a specified number. */
-  ratchetPercentagePadding?: number;
+  /** Keeps the threshold below the measured coverage, allowing wiggle room. Default: zero tolerance */
+  tolerance?: number;
 
-  /** After set period timeout waiting for changes. Default: wait forever */
+  /** After set period timeout waiting for changes. Default: wait indefinitely */
   timeout?: number;
 
-  /** Round percentage thresholds down to the nearest percentage. */
-  floorPct?: boolean;
+  /** Round percentage thresholds down to the nearest integer. Default: false */
+  roundDown?: boolean;
 }
 
 export interface Config {

--- a/src/ratchet.ts
+++ b/src/ratchet.ts
@@ -42,11 +42,11 @@ function ratchetSingleNumberCoverage(
   options: RatchetOptions,
 ) {
   if (num && category) {
-    const ratchetPct = options.ratchetPercentagePadding
-      ? Math.round(category.pct) - options.ratchetPercentagePadding
+    const tolerance = options.tolerance
+      ? Math.round(category.pct) - options.tolerance
       : category.pct;
-    if (num > 0 && num <= ratchetPct) {
-      return options.floorPct ? Math.floor(ratchetPct) : ratchetPct;
+    if (num > 0 && num <= tolerance) {
+      return options.roundDown ? Math.floor(tolerance) : tolerance;
     } else if (num < 0 && num >= -category.covered) {
       return -category.covered;
     }

--- a/src/test.ts
+++ b/src/test.ts
@@ -149,7 +149,7 @@ describe('jest-ratchet', () => {
       ...threshold,
       rootDir: './example',
     }, {
-      floorPct: true,
+      roundDown: true,
     });
     jestRatchet.onRunComplete();
 
@@ -167,7 +167,7 @@ describe('jest-ratchet', () => {
   });
 
   it('will pad the ratchet percentages', () => {
-    const PADDING = 2;
+    const TOLERANCE = 2;
     const threshold = {
       coverageThreshold: {
         global: {
@@ -193,7 +193,7 @@ describe('jest-ratchet', () => {
       ...threshold,
       rootDir: './example',
     }, {
-      ratchetPercentagePadding: PADDING,
+      tolerance: TOLERANCE,
     });
     jestRatchet.onRunComplete();
 


### PR DESCRIPTION
The option names are a little verbose and maybe confusing to anyone who isn't completely familiar with the inner-workings of Jest and the coverage reporters.

`ratchetPercentagePadding` -> `tolerance`
`floorPct` -> `roundDown`

** This is a breaking change and should probably warrant a 2.0 version **