### PR TITLE
jest-ratchet 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ Add `jest-ratchet` to the `reporters` section. And also ensure that `collectCove
 
 By default, Jest-Ratchet is aggressive with updating coverage thresholds. Every time your coverage ticks up by 0.01%, the coverageThreshold is updated. There are a couple of options dampen this behavior.
 
-- ratchetPercentagePadding (number): keeps the threshold below the measured coverage, allowing wiggle room
-- floorPct (boolean): round down to the nearest integer
-
-There's also a _timeout (number)_ option, the number of milliseconds to wait for changes. The default is to wait forever.
+- tolerance (number): keeps the threshold below the measured coverage, allowing wiggle room. default: 0 tolerance
+- roundDown (boolean): round down to the nearest integer. default: false
+- timeout (number): the number of milliseconds to wait for to the Jest coverage json summary. default: wait indefinitely
 
 Here's how to pass configuration to Jest-Ratchet, per the [Jest documentation](https://jestjs.io/docs/en/configuration.html#reporters-array-modulename-modulename-options)
 
@@ -55,7 +54,7 @@ Here's how to pass configuration to Jest-Ratchet, per the [Jest documentation](h
     "default",
     [
       "jest-ratchet",
-      { "ratchetPercentagePadding": 2, "floorPct": true, "timeout": 5000 }
+      { "tolerance": 2, "roundDown": true, "timeout": 5000 }
     ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "index.js",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "repository": {
     "type": "git",
@@ -35,10 +35,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80,
-        "statements": 80
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
       }
     },
     "testPathIgnorePatterns": [

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,22 +1,41 @@
+/* tslint:disable:max-classes-per-file */
+
 import { Config } from './interfaces';
 
 export const NAME = 'jest-ratchet';
 
-export function getLastError(config: Config) {
-  const errors: string[] = [];
+export const getLastError = (config: Config) => {
   const { collectCoverage, coverageReporters} = config;
-  if ((coverageReporters || []).indexOf('json-summary') === -1) {
-    errors.push(
-      `'json-summary' needs to be listed as a coverageReporter in order for ${ NAME } to work appropriately.`,
-    );
-  }
   if (!collectCoverage) {
-    errors.push(
-      `'collectCoverage' option needs to be enabled in order for ${ NAME } to work appropriately.`,
-    );
+    throw new CollectCoverageError();
   }
+  if ((coverageReporters || []).indexOf('json-summary') === -1) {
+    throw new JsonSummaryError();
+  }
+};
 
-  if (errors.length > 0) {
-    throw new Error(errors.join('\n'));
+export const tryOrReject = async (reject: (reason?: any) => void, cb: () => void) => {
+  try {
+    cb();
+  } catch (e) {
+    reject(e);
+  }
+};
+
+export class JsonSummaryError extends Error {
+  constructor() {
+    super(`'json-summary' needs to be listed as a coverageReporter in order for ${ NAME } to work appropriately.`);
+  }
+}
+
+export class CollectCoverageError extends Error {
+  constructor() {
+    super(`'collectCoverage' option needs to be enabled in order for ${ NAME } to work appropriately.`);
+  }
+}
+
+export class TimeoutError extends Error {
+  constructor(public coverageDirectory?: string, public timeout?: number) {
+    super('Jest-Ratchet timed-out waiting for the Coverage Summary');
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,7 +14,7 @@ export const getLastError = (config: Config) => {
   }
 };
 
-export const tryOrReject = async (reject: (reason?: any) => void, cb: () => void) => {
+export const tryOrReject = (reject: (reason?: any) => void, cb: () => void) => {
   try {
     cb();
   } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export default class JestRatchet {
   }
 }
 
-const onRunComplete = async (
+const onRunComplete = (
   globalConfig: Config,
   options: RatchetOptions,
 ): Promise<void> => new Promise(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, watch } from 'fs';
 
-import { getLastError } from './errors';
+import { getLastError, TimeoutError, tryOrReject } from './errors';
 import {
   Config,
   IstanbulCoverage,
@@ -16,52 +16,63 @@ import { noop } from './noop';
 import { ratchetCoverage } from './ratchet';
 
 export default class JestRatchet {
-  public getLastError: () => void = noop;
+  public getLastError: () => Error | void = noop;
   public onRunComplete: () => void = noop;
+  public runResult = Promise.resolve();
 
   constructor(
     globalConfig: Config,
     options: RatchetOptions = {},
   ) {
     if (!process.env.DISABLE_JEST_RATCHET) {
-      onRunComplete(globalConfig, options);
       this.getLastError = getLastError.bind(this, globalConfig);
+      this.runResult = onRunComplete(globalConfig, options);
+      this.runResult.catch(e => {
+        this.getLastError = () => { throw e; };
+      });
     }
   }
 }
 
-function onRunComplete(globalConfig: Config, options: RatchetOptions) {
-  try {
-    const coverageDirectory = findCoveragePath(globalConfig);
-    const coverageSummaryPath = findCoverageSummaryPath(coverageDirectory);
-    const jestConfigPath = findJestConfigPath(process.cwd(), process.argv);
+const onRunComplete = async (
+  globalConfig: Config,
+  options: RatchetOptions,
+): Promise<void> => new Promise(
+  (resolve, reject) => {
+    tryOrReject(reject, () => {
+      const coverageDirectory = findCoveragePath(globalConfig);
+      const coverageSummaryPath = findCoverageSummaryPath(coverageDirectory);
+      const jestConfigPath = findJestConfigPath(process.cwd(), process.argv);
 
-    if (!existsSync(coverageDirectory)) {
-      mkdirSync(coverageDirectory);
-    }
-    if (!existsSync(coverageSummaryPath)) {
-      closeSync(openSync(coverageSummaryPath, 'w'));
-    }
-
-    const watcher = watch(coverageDirectory);
-    const closeWatcher = () => watcher.close();
-    const timeoutTimer = options.timeout && setTimeout(closeWatcher, options.timeout);
-
-    watcher.once('change', () => {
-      closeWatcher();
-      if (timeoutTimer) {
-        clearTimeout(timeoutTimer);
+      if (!existsSync(coverageDirectory)) {
+        mkdirSync(coverageDirectory);
+      }
+      if (!existsSync(coverageSummaryPath)) {
+        closeSync(openSync(coverageSummaryPath, 'w'));
       }
 
-      const coverageRaw = readFileSync(coverageSummaryPath, 'utf-8');
-      const summary: IstanbulCoverage = JSON.parse(coverageRaw);
-      const threshold = globalConfig.coverageThreshold!;
-      const ratchetResult = ratchetCoverage(threshold, summary, options);
+      const watcher = watch(coverageDirectory);
+      const timeout = options.timeout;
 
-      updateFile(jestConfigPath, ratchetResult);
+      const timeoutTimer = timeout && setTimeout(() => {
+        watcher.close();
+        reject(new TimeoutError(coverageDirectory, timeout));
+      }, timeout);
+
+      watcher.once('change', () => tryOrReject(reject, () => {
+        watcher.close();
+        if (timeoutTimer) {
+          clearTimeout(timeoutTimer);
+        }
+
+        const coverageRaw = readFileSync(coverageSummaryPath, 'utf-8');
+        const summary: IstanbulCoverage = JSON.parse(coverageRaw);
+        const threshold = globalConfig.coverageThreshold!;
+        const ratchetResult = ratchetCoverage(threshold, summary, options);
+
+        updateFile(jestConfigPath, ratchetResult);
+        resolve();
+      }));
     });
-  } catch (e) {
-    // tslint:disable-next-line
-    console.error(e);
-  }
-}
+  },
+);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -33,14 +33,14 @@ export interface JestCoverageCategory {
 }
 
 export interface RatchetOptions {
-  /** Pad the ratchet percentage by a specified number. */
-  ratchetPercentagePadding?: number;
+  /** Keeps the threshold below the measured coverage, allowing wiggle room. Default: zero tolerance */
+  tolerance?: number;
 
-  /** After set period timeout waiting for changes. Default: wait forever */
+  /** After set period timeout waiting for changes. Default: wait indefinitely */
   timeout?: number;
 
-  /** Round percentage thresholds down to the nearest percentage. */
-  floorPct?: boolean;
+  /** Round percentage thresholds down to the nearest integer. Default: false */
+  roundDown?: boolean;
 }
 
 export interface Config {

--- a/src/json.ts
+++ b/src/json.ts
@@ -5,7 +5,7 @@ import { JestCoverage } from './interfaces';
 
 const inplace = _inplace as typeof _inplace.default;
 
-export function updateFile(fileName: string, result: JestCoverage) {
+export const updateFile = (fileName: string, result: JestCoverage) => {
   const jestConfigRaw = readFileSync(fileName, 'utf-8');
   const jestConfig = JSON.parse(jestConfigRaw);
 
@@ -13,13 +13,13 @@ export function updateFile(fileName: string, result: JestCoverage) {
   const newFile = setCoverage(jestConfigRaw, result, prefix);
 
   writeFileSync(fileName, newFile, 'utf-8');
-}
+};
 
-export function setCoverage(
+export const setCoverage = (
   source: string,
   result: JestCoverage,
   prefix: string,
-): string {
+): string => {
   prefix += 'coverageThreshold.';
   const newSource = inplace(source);
   for (const key of Object.keys(result)) {
@@ -37,4 +37,4 @@ export function setCoverage(
     }
   }
   return newSource.toString();
-}
+};

--- a/src/locations.ts
+++ b/src/locations.ts
@@ -6,7 +6,7 @@ import { Config } from './interfaces';
 type Argv = typeof process.argv;
 const parser = _parser as typeof _parser.default;
 
-export function findJestConfigPath(cwd: string, argv: Argv) {
+export const findJestConfigPath = (cwd: string, argv: Argv) => {
   let configLocation = 'package.json';
   const args = parser(argv.slice(2));
   if (args && args.config) {
@@ -17,9 +17,9 @@ export function findJestConfigPath(cwd: string, argv: Argv) {
   }
 
   return configLocation;
-}
+};
 
-export function findCoveragePath(config: Config) {
+export const findCoveragePath = (config: Config) => {
   if (config.coverageDirectory) {
     return config.coverageDirectory;
   }
@@ -27,8 +27,8 @@ export function findCoveragePath(config: Config) {
     return resolve(config.rootDir, 'coverage');
   }
   return resolve(process.cwd(), 'coverage');
-}
+};
 
-export function findCoverageSummaryPath(coverageDirectory: string) {
+export const findCoverageSummaryPath = (coverageDirectory: string) => {
   return resolve(coverageDirectory, 'coverage-summary.json');
-}
+};

--- a/src/ratchet.ts
+++ b/src/ratchet.ts
@@ -7,11 +7,11 @@ import {
   RatchetOptions,
 } from './interfaces';
 
-export function ratchetCoverage(
+export const ratchetCoverage = (
   threshold: JestCoverage,
   summary: IstanbulCoverage,
   options: RatchetOptions,
-): JestCoverage {
+): JestCoverage => {
   const result: any = {};
   if (threshold) {
     for (const key of Object.keys(threshold)) {
@@ -20,13 +20,13 @@ export function ratchetCoverage(
     }
   }
   return result;
-}
+};
 
-function ratchetSingleCoverage(
+const ratchetSingleCoverage = (
   threshold: JestCoverageCategory,
   summary: IstanbulCoverageCategories,
   options: RatchetOptions,
-) {
+) => {
   const { branches, functions, lines, statements } = threshold;
   return {
     branches: ratchetSingleNumberCoverage(branches, summary.branches, options),
@@ -34,13 +34,13 @@ function ratchetSingleCoverage(
     lines: ratchetSingleNumberCoverage(lines, summary.lines, options),
     statements: ratchetSingleNumberCoverage(statements, summary.statements, options),
   };
-}
+};
 
-function ratchetSingleNumberCoverage(
+const ratchetSingleNumberCoverage = (
   num: number | undefined,
   category: IstanbulCoverageCategory,
   options: RatchetOptions,
-) {
+) => {
   if (num && category) {
     const tolerance = options.tolerance
       ? Math.round(category.pct) - options.tolerance
@@ -51,4 +51,4 @@ function ratchetSingleNumberCoverage(
       return -category.covered;
     }
   }
-}
+};

--- a/src/ratchet.ts
+++ b/src/ratchet.ts
@@ -42,11 +42,11 @@ function ratchetSingleNumberCoverage(
   options: RatchetOptions,
 ) {
   if (num && category) {
-    const ratchetPct = options.ratchetPercentagePadding
-      ? Math.round(category.pct) - options.ratchetPercentagePadding
+    const tolerance = options.tolerance
+      ? Math.round(category.pct) - options.tolerance
       : category.pct;
-    if (num > 0 && num <= ratchetPct) {
-      return options.floorPct ? Math.floor(ratchetPct) : ratchetPct;
+    if (num > 0 && num <= tolerance) {
+      return options.roundDown ? Math.floor(tolerance) : tolerance;
     } else if (num < 0 && num >= -category.covered) {
       return -category.covered;
     }

--- a/src/test.ts
+++ b/src/test.ts
@@ -149,7 +149,7 @@ describe('jest-ratchet', () => {
       ...threshold,
       rootDir: './example',
     }, {
-      floorPct: true,
+      roundDown: true,
     });
     jestRatchet.onRunComplete();
 
@@ -167,7 +167,7 @@ describe('jest-ratchet', () => {
   });
 
   it('will pad the ratchet percentages', () => {
-    const PADDING = 2;
+    const TOLERANCE = 2;
     const threshold = {
       coverageThreshold: {
         global: {
@@ -193,7 +193,7 @@ describe('jest-ratchet', () => {
       ...threshold,
       rootDir: './example',
     }, {
-      ratchetPercentagePadding: PADDING,
+      tolerance: TOLERANCE,
     });
     jestRatchet.onRunComplete();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
-    "lib": [ "dom", "es6" ],
+    "target": "es2015",
+    "lib": [ "es2015" ],
     "removeComments": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
Breaking changes introduced in jest-ratchet 2.0:

* Output es2015 javascript instead of es5 javascript
* Rename options to make more sense:
`ratchetPercentagePadding` -> `tolerance`
`floorPct` -> `roundDown`
* Increase test coverage to 100%
