### PR TITLE
Output es2015 instead of es5

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80,
-        "statements": 80
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
       }
     },
     "testPathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "index.js",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "repository": {
     "type": "git",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,22 +1,41 @@
+/* tslint:disable:max-classes-per-file */
+
 import { Config } from './interfaces';
 
 export const NAME = 'jest-ratchet';
 
 export const getLastError = (config: Config) => {
-  const errors: string[] = [];
   const { collectCoverage, coverageReporters} = config;
-  if ((coverageReporters || []).indexOf('json-summary') === -1) {
-    errors.push(
-      `'json-summary' needs to be listed as a coverageReporter in order for ${ NAME } to work appropriately.`,
-    );
-  }
   if (!collectCoverage) {
-    errors.push(
-      `'collectCoverage' option needs to be enabled in order for ${ NAME } to work appropriately.`,
-    );
+    throw new CollectCoverageError();
   }
-
-  if (errors.length > 0) {
-    throw new Error(errors.join('\n'));
+  if ((coverageReporters || []).indexOf('json-summary') === -1) {
+    throw new JsonSummaryError();
   }
 };
+
+export const tryOrReject = async (reject: (reason?: any) => void, cb: () => void) => {
+  try {
+    cb();
+  } catch (e) {
+    reject(e);
+  }
+};
+
+export class JsonSummaryError extends Error {
+  constructor() {
+    super(`'json-summary' needs to be listed as a coverageReporter in order for ${ NAME } to work appropriately.`);
+  }
+}
+
+export class CollectCoverageError extends Error {
+  constructor() {
+    super(`'collectCoverage' option needs to be enabled in order for ${ NAME } to work appropriately.`);
+  }
+}
+
+export class TimeoutError extends Error {
+  constructor(public coverageDirectory?: string, public timeout?: number) {
+    super('Jest-Ratchet timed-out waiting for the Coverage Summary');
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,7 +2,7 @@ import { Config } from './interfaces';
 
 export const NAME = 'jest-ratchet';
 
-export function getLastError(config: Config) {
+export const getLastError = (config: Config) => {
   const errors: string[] = [];
   const { collectCoverage, coverageReporters} = config;
   if ((coverageReporters || []).indexOf('json-summary') === -1) {
@@ -19,4 +19,4 @@ export function getLastError(config: Config) {
   if (errors.length > 0) {
     throw new Error(errors.join('\n'));
   }
-}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, watch } from 'fs';
 
-import { getLastError } from './errors';
+import { getLastError, TimeoutError, tryOrReject } from './errors';
 import {
   Config,
   IstanbulCoverage,
@@ -16,52 +16,63 @@ import { noop } from './noop';
 import { ratchetCoverage } from './ratchet';
 
 export default class JestRatchet {
-  public getLastError: () => void = noop;
+  public getLastError: () => Error | void = noop;
   public onRunComplete: () => void = noop;
+  public runResult = Promise.resolve();
 
   constructor(
     globalConfig: Config,
     options: RatchetOptions = {},
   ) {
     if (!process.env.DISABLE_JEST_RATCHET) {
-      onRunComplete(globalConfig, options);
       this.getLastError = getLastError.bind(this, globalConfig);
+      this.runResult = onRunComplete(globalConfig, options);
+      this.runResult.catch(e => {
+        this.getLastError = () => { throw e; };
+      });
     }
   }
 }
 
-const onRunComplete = (globalConfig: Config, options: RatchetOptions) => {
-  try {
-    const coverageDirectory = findCoveragePath(globalConfig);
-    const coverageSummaryPath = findCoverageSummaryPath(coverageDirectory);
-    const jestConfigPath = findJestConfigPath(process.cwd(), process.argv);
+const onRunComplete = async (
+  globalConfig: Config,
+  options: RatchetOptions,
+): Promise<void> => new Promise(
+  (resolve, reject) => {
+    tryOrReject(reject, () => {
+      const coverageDirectory = findCoveragePath(globalConfig);
+      const coverageSummaryPath = findCoverageSummaryPath(coverageDirectory);
+      const jestConfigPath = findJestConfigPath(process.cwd(), process.argv);
 
-    if (!existsSync(coverageDirectory)) {
-      mkdirSync(coverageDirectory);
-    }
-    if (!existsSync(coverageSummaryPath)) {
-      closeSync(openSync(coverageSummaryPath, 'w'));
-    }
-
-    const watcher = watch(coverageDirectory);
-    const closeWatcher = () => watcher.close();
-    const timeoutTimer = options.timeout && setTimeout(closeWatcher, options.timeout);
-
-    watcher.once('change', () => {
-      closeWatcher();
-      if (timeoutTimer) {
-        clearTimeout(timeoutTimer);
+      if (!existsSync(coverageDirectory)) {
+        mkdirSync(coverageDirectory);
+      }
+      if (!existsSync(coverageSummaryPath)) {
+        closeSync(openSync(coverageSummaryPath, 'w'));
       }
 
-      const coverageRaw = readFileSync(coverageSummaryPath, 'utf-8');
-      const summary: IstanbulCoverage = JSON.parse(coverageRaw);
-      const threshold = globalConfig.coverageThreshold!;
-      const ratchetResult = ratchetCoverage(threshold, summary, options);
+      const watcher = watch(coverageDirectory);
+      const timeout = options.timeout;
 
-      updateFile(jestConfigPath, ratchetResult);
+      const timeoutTimer = timeout && setTimeout(() => {
+        watcher.close();
+        reject(new TimeoutError(coverageDirectory, timeout));
+      }, timeout);
+
+      watcher.once('change', () => tryOrReject(reject, () => {
+        watcher.close();
+        if (timeoutTimer) {
+          clearTimeout(timeoutTimer);
+        }
+
+        const coverageRaw = readFileSync(coverageSummaryPath, 'utf-8');
+        const summary: IstanbulCoverage = JSON.parse(coverageRaw);
+        const threshold = globalConfig.coverageThreshold!;
+        const ratchetResult = ratchetCoverage(threshold, summary, options);
+
+        updateFile(jestConfigPath, ratchetResult);
+        resolve();
+      }));
     });
-  } catch (e) {
-    // tslint:disable-next-line
-    console.error(e);
-  }
-};
+  },
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export default class JestRatchet {
   }
 }
 
-function onRunComplete(globalConfig: Config, options: RatchetOptions) {
+const onRunComplete = (globalConfig: Config, options: RatchetOptions) => {
   try {
     const coverageDirectory = findCoveragePath(globalConfig);
     const coverageSummaryPath = findCoverageSummaryPath(coverageDirectory);
@@ -64,4 +64,4 @@ function onRunComplete(globalConfig: Config, options: RatchetOptions) {
     // tslint:disable-next-line
     console.error(e);
   }
-}
+};

--- a/src/json.ts
+++ b/src/json.ts
@@ -5,7 +5,7 @@ import { JestCoverage } from './interfaces';
 
 const inplace = _inplace as typeof _inplace.default;
 
-export function updateFile(fileName: string, result: JestCoverage) {
+export const updateFile = (fileName: string, result: JestCoverage) => {
   const jestConfigRaw = readFileSync(fileName, 'utf-8');
   const jestConfig = JSON.parse(jestConfigRaw);
 
@@ -13,13 +13,13 @@ export function updateFile(fileName: string, result: JestCoverage) {
   const newFile = setCoverage(jestConfigRaw, result, prefix);
 
   writeFileSync(fileName, newFile, 'utf-8');
-}
+};
 
-export function setCoverage(
+export const setCoverage = (
   source: string,
   result: JestCoverage,
   prefix: string,
-): string {
+): string => {
   prefix += 'coverageThreshold.';
   const newSource = inplace(source);
   for (const key of Object.keys(result)) {
@@ -37,4 +37,4 @@ export function setCoverage(
     }
   }
   return newSource.toString();
-}
+};

--- a/src/locations.ts
+++ b/src/locations.ts
@@ -6,7 +6,7 @@ import { Config } from './interfaces';
 type Argv = typeof process.argv;
 const parser = _parser as typeof _parser.default;
 
-export function findJestConfigPath(cwd: string, argv: Argv) {
+export const findJestConfigPath = (cwd: string, argv: Argv) => {
   let configLocation = 'package.json';
   const args = parser(argv.slice(2));
   if (args && args.config) {
@@ -17,9 +17,9 @@ export function findJestConfigPath(cwd: string, argv: Argv) {
   }
 
   return configLocation;
-}
+};
 
-export function findCoveragePath(config: Config) {
+export const findCoveragePath = (config: Config) => {
   if (config.coverageDirectory) {
     return config.coverageDirectory;
   }
@@ -27,8 +27,8 @@ export function findCoveragePath(config: Config) {
     return resolve(config.rootDir, 'coverage');
   }
   return resolve(process.cwd(), 'coverage');
-}
+};
 
-export function findCoverageSummaryPath(coverageDirectory: string) {
+export const findCoverageSummaryPath = (coverageDirectory: string) => {
   return resolve(coverageDirectory, 'coverage-summary.json');
-}
+};

--- a/src/ratchet.ts
+++ b/src/ratchet.ts
@@ -7,11 +7,11 @@ import {
   RatchetOptions,
 } from './interfaces';
 
-export function ratchetCoverage(
+export const ratchetCoverage = (
   threshold: JestCoverage,
   summary: IstanbulCoverage,
   options: RatchetOptions,
-): JestCoverage {
+): JestCoverage => {
   const result: any = {};
   if (threshold) {
     for (const key of Object.keys(threshold)) {
@@ -20,13 +20,13 @@ export function ratchetCoverage(
     }
   }
   return result;
-}
+};
 
-function ratchetSingleCoverage(
+const ratchetSingleCoverage = (
   threshold: JestCoverageCategory,
   summary: IstanbulCoverageCategories,
   options: RatchetOptions,
-) {
+) => {
   const { branches, functions, lines, statements } = threshold;
   return {
     branches: ratchetSingleNumberCoverage(branches, summary.branches, options),
@@ -34,13 +34,13 @@ function ratchetSingleCoverage(
     lines: ratchetSingleNumberCoverage(lines, summary.lines, options),
     statements: ratchetSingleNumberCoverage(statements, summary.statements, options),
   };
-}
+};
 
-function ratchetSingleNumberCoverage(
+const ratchetSingleNumberCoverage = (
   num: number | undefined,
   category: IstanbulCoverageCategory,
   options: RatchetOptions,
-) {
+) => {
   if (num && category) {
     const ratchetPct = options.ratchetPercentagePadding
       ? Math.round(category.pct) - options.ratchetPercentagePadding
@@ -51,4 +51,4 @@ function ratchetSingleNumberCoverage(
       return -category.covered;
     }
   }
-}
+};

--- a/src/test.ts
+++ b/src/test.ts
@@ -2,7 +2,14 @@ jest.mock('fs');
 
 import * as _fs from 'fs';
 import { resolve } from 'path';
+import {
+  CollectCoverageError,
+  JsonSummaryError,
+  TimeoutError,
+  tryOrReject,
+} from './errors';
 import JestRatchet from './index';
+import { findCoveragePath } from './locations';
 import { noop } from './noop';
 
 type extFs = typeof _fs & {
@@ -30,70 +37,20 @@ describe('jest-ratchet', () => {
     delete process.env.DISABLE_JEST_RATCHET;
   });
 
-  it('will initialize without error', () => {
-    const config = {
-      ...mockConfig,
-      collectCoverage: true,
-      coverageReporters: ['json-summary'],
-    };
-    const jestRatchet = new JestRatchet(config);
-
-    expect(jestRatchet.getLastError).not.toThrowError();
-  });
-
-  it('will throw error when collectCoverage is not enabled', () => {
-    const config = {
-      ...mockConfig,
-      collectCoverage: false,
-      coverageReporters: undefined,
-    };
-    const jestRatchet = new JestRatchet(config);
-
-    expect(jestRatchet.getLastError).toThrowError(/collectCoverage/);
-  });
-
-  it('will handle errors from onRunComplete', () => {
-    // tslint:disable-next-line
-    console.error = jest.fn();
-
-    const jestRatchet = new JestRatchet(mockConfig);
-    jestRatchet.onRunComplete();
-  });
-
-  it('will do nothing when ratchet is disabled', () => {
-    process.env.DISABLE_JEST_RATCHET = 'true';
-
-    const jestRatchet = new JestRatchet(mockConfig);
-
-    expect(jestRatchet.onRunComplete).toBe(noop);
-  });
-
   it('will ratchet percentages', () => {
     const threshold = {
       coverageThreshold: {
         global: {
           branches: 50,
-          functions: 50,
-          lines: 50,
-          statements: 50,
         },
       },
     };
-    fs.__addMockFile(
-      /\/coverage-summary\.json$/,
-      JSON.stringify({
-        total: {
-          branches: {pct: 100},
-          functions: {pct: 100},
-          lines: {pct: 100},
-          statements: {pct: 100},
-        },
-      }),
-    );
-    fs.__addMockFile(
-      /\/package\.json$/,
-      JSON.stringify({ ...threshold }),
-    );
+    setCoverageSummaryFile(fs, {
+      total: {
+        branches: {pct: 100},
+      },
+    });
+    setPackageJson(fs, { ...threshold });
 
     const jestRatchet = new JestRatchet({
       ...mockConfig,
@@ -102,19 +59,71 @@ describe('jest-ratchet', () => {
     });
     jestRatchet.onRunComplete();
 
-    const writeFileSync = fs.writeFileSync as jest.Mock;
-    expect(writeFileSync.mock.calls[0][1])
-      .toEqual(
-        JSON.stringify({
-          coverageThreshold: {
-            global: {
-              branches: 100,
-              functions: 100,
-              lines: 100,
-              statements: 100,
-            },
-          },
-        }));
+    expectCoverageThreshold({
+      coverageThreshold: {
+        global: {
+          branches: 100,
+        },
+      },
+    });
+  });
+
+  it('will ratchet non-global percentages', () => {
+    const threshold = {
+      coverageThreshold: {
+        global: {
+          branches: 50,
+          functions: 50,
+          lines: 50,
+          statements: 50,
+        },
+        specific: {
+          branches: 50,
+          functions: 50,
+          lines: 50,
+          statements: 50,
+        },
+      },
+    };
+    setCoverageSummaryFile(fs, {
+      specific: {
+        branches: {pct: 100},
+        functions: {pct: 100},
+        lines: {pct: 100},
+        statements: {pct: 100},
+      },
+      total: {
+        branches: {pct: 100},
+        functions: {pct: 100},
+        lines: {pct: 100},
+        statements: {pct: 100},
+      },
+    });
+    setPackageJson(fs, { ...threshold });
+
+    const jestRatchet = new JestRatchet({
+      ...mockConfig,
+      ...threshold,
+      rootDir: './example',
+    });
+    jestRatchet.onRunComplete();
+
+    expectCoverageThreshold({
+      coverageThreshold: {
+        global: {
+          branches: 100,
+          functions: 100,
+          lines: 100,
+          statements: 100,
+        },
+        specific: {
+          branches: 100,
+          functions: 100,
+          lines: 100,
+          statements: 100,
+        },
+      },
+    });
   });
 
   it('will round down percentages', () => {
@@ -128,21 +137,15 @@ describe('jest-ratchet', () => {
         },
       },
     };
-    fs.__addMockFile(
-      /\/coverage-summary\.json$/,
-      JSON.stringify({
-        total: {
-          branches: {pct: 98.7},
-          functions: {pct: 51.3},
-          lines: {pct: 70.6},
-          statements: {pct: 75.8},
-        },
-      }),
-    );
-    fs.__addMockFile(
-      /\/package\.json$/,
-      JSON.stringify({ ...threshold }),
-    );
+    setCoverageSummaryFile(fs, {
+      total: {
+        branches: {pct: 98.7},
+        functions: {pct: 51.3},
+        lines: {pct: 70.6},
+        statements: {pct: 75.8},
+      },
+    });
+    setPackageJson(fs, { ...threshold });
 
     const jestRatchet = new JestRatchet({
       ...mockConfig,
@@ -153,8 +156,7 @@ describe('jest-ratchet', () => {
     });
     jestRatchet.onRunComplete();
 
-    const writeFileSync = fs.writeFileSync as jest.Mock;
-    expect(writeFileSync).toHaveBeenCalledWith(expect.anything(), JSON.stringify({
+    expectCoverageThreshold({
       coverageThreshold: {
         global: {
           branches: 98,
@@ -163,7 +165,7 @@ describe('jest-ratchet', () => {
           statements: 75,
         },
       },
-    }), expect.anything());
+    });
   });
 
   it('will pad the ratchet percentages', () => {
@@ -175,38 +177,28 @@ describe('jest-ratchet', () => {
         },
       },
     };
-    fs.__addMockFile(
-      /\/coverage-summary\.json$/,
-      JSON.stringify({
-        total: {
-          branches: {pct: 100},
-        },
-      }),
-    );
-    fs.__addMockFile(
-      /\/package\.json$/,
-      JSON.stringify({ ...threshold }),
-    );
+    setCoverageSummaryFile(fs, {
+      total: {
+        branches: {pct: 100},
+      },
+    });
+    setPackageJson(fs, { ...threshold });
 
     const jestRatchet = new JestRatchet({
       ...mockConfig,
       ...threshold,
-      rootDir: './example',
     }, {
       ratchetPercentagePadding: PADDING,
     });
     jestRatchet.onRunComplete();
 
-    const writeFileSync = fs.writeFileSync as jest.Mock;
-    expect(writeFileSync.mock.calls[0][1])
-      .toEqual(
-        JSON.stringify({
-          coverageThreshold: {
-            global: {
-              branches: 98,
-            },
-          },
-        }));
+    expectCoverageThreshold({
+      coverageThreshold: {
+        global: {
+          branches: 98,
+        },
+      },
+    });
   });
 
   it('will respect the --config flag', () => {
@@ -221,59 +213,153 @@ describe('jest-ratchet', () => {
         },
       },
     };
-    fs.__addMockFile(
-      /\/coverage-summary\.json$/,
-      JSON.stringify({
-        total: {
-          branches: {covered: 100},
-          functions: {covered: 100},
-          lines: {covered: 100},
-          statements: {covered: 100},
-        },
-      }),
-    );
-    fs.__addMockFile(
-      /\/jestconfig\.json$/,
-      JSON.stringify({ ...threshold }),
-    );
+    setCoverageSummaryFile(fs, {
+      total: {
+        branches: {covered: 100},
+        functions: {covered: 100},
+        lines: {covered: 100},
+        statements: {covered: 100},
+      },
+    });
+    setJestConfig(fs, { ...threshold });
 
     const jestRatchet = new JestRatchet({ ...mockConfig, ...threshold });
     jestRatchet.onRunComplete();
 
-    const writeFileSync = fs.writeFileSync as jest.Mock;
-    expect(writeFileSync.mock.calls[0][1])
-      .toEqual(
-        JSON.stringify({
-          coverageThreshold: {
-            global: {
-              branches: -100,
-              functions: -100,
-              lines: -100,
-              statements: -100,
-            },
-          },
-        }));
+    expectCoverageThreshold({
+      coverageThreshold: {
+        global: {
+          branches: -100,
+          functions: -100,
+          lines: -100,
+          statements: -100,
+        },
+      },
+    });
   });
 
-  it('will handle edge cases', () => {
-    const threshold = {
-      coverageThreshold: {
-        global: { bogus: {}},
-      },
-    } as any;
-    fs.__addMockFile(
+  const setCoverageSummaryFile = (mockfs: extFs, json: any) => {
+    mockfs.__addMockFile(
       /\/coverage-summary\.json$/,
-      JSON.stringify({
-        total: { bogus: {} },
-      }),
+      JSON.stringify(json),
     );
-    fs.__addMockFile(
-      /\/jestconfig\.json$/,
-      JSON.stringify({ ...threshold }),
-    );
-    fs.existsSync = () => true;
+  };
 
-    const jestRatchet = new JestRatchet({ ...mockConfig, ...threshold });
+  const setPackageJson = (mockfs: extFs, json: any) => {
+    mockfs.__addMockFile(
+      /\/package\.json$/,
+      JSON.stringify(json),
+    );
+  };
+
+  const setJestConfig = (mockfs: extFs, json: any) => {
+    mockfs.__addMockFile(
+      /\/jestconfig\.json$/,
+      JSON.stringify(json),
+    );
+  };
+
+  const expectCoverageThreshold = (threshold: any) => {
+    const writeFileSync = fs.writeFileSync as jest.Mock;
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.anything(),
+      JSON.stringify({...threshold}),
+      expect.anything(),
+    );
+  };
+});
+
+describe('jest-ratchet non-core', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    fs.__resetMockFiles();
+    process.cwd = jest.fn().mockReturnValue(resolve('./example'));
+    process.argv = originalArgv;
+    process.env = { ...originalEnv };
+    delete process.env.DISABLE_JEST_RATCHET;
+  });
+
+  it('will initialize without error', () => {
+    const config = {
+      ...mockConfig,
+      collectCoverage: true,
+      coverageReporters: ['json-summary'],
+    };
+    const jestRatchet = new JestRatchet(config);
+
+    expect(jestRatchet.getLastError).not.toThrowError();
+  });
+
+  it('will throw error when json-summary is not enabled', () => {
+    const config = {
+      ...mockConfig,
+      collectCoverage: true,
+      coverageReporters: undefined,
+    };
+    const jestRatchet = new JestRatchet(config);
+
+    expect(jestRatchet.getLastError).toThrowError(JsonSummaryError);
+  });
+
+  it('will throw error when collectCoverage is not enabled', () => {
+    const config = {
+      ...mockConfig,
+      collectCoverage: false,
+      coverageReporters: undefined,
+    };
+    const jestRatchet = new JestRatchet(config);
+
+    expect(jestRatchet.getLastError).toThrowError(CollectCoverageError);
+  });
+
+  it('will do nothing when ratchet is disabled', () => {
+    process.env.DISABLE_JEST_RATCHET = 'true';
+
+    const jestRatchet = new JestRatchet(mockConfig);
+    expect(jestRatchet.onRunComplete).toBe(noop);
+    expect(jestRatchet.getLastError).toBe(noop);
+  });
+
+  it('will throw a timeout error', async () => {
+    fs.watch = () => ({
+      close: jest.fn(),
+      on: jest.fn(),
+      once: jest.fn(),
+    }) as any;
+
+    const jestRatchet = new JestRatchet({ ...mockConfig }, { timeout: 5 });
+    await expect(jestRatchet.runResult).rejects.toBeInstanceOf(TimeoutError);
+    expect(jestRatchet.getLastError).toThrowError(TimeoutError);
+  });
+
+  it('will cleanup timeout', () => {
+    jest.useFakeTimers();
+    fs.watch = () => ({
+      close: jest.fn(),
+      once: jest.fn().mockImplementation((_: string, cb: () => void) => { cb(); }),
+    }) as any;
+
+    const jestRatchet = new JestRatchet({ ...mockConfig }, { timeout: 100 });
     jestRatchet.onRunComplete();
+
+    expect(clearTimeout).toBeCalled();
+  });
+});
+
+describe('edges', () => {
+  it('tryOrReject will reject', () => {
+    const reject = jest.fn();
+    tryOrReject(reject, () => { throw new Error(); });
+    expect(reject).toBeCalled();
+  });
+
+  it('findCoveragePath will return coverageDirectory', () => {
+    const coverageDirectory = 'COVERAGE_DIRECTORY';
+    expect(findCoveragePath({coverageDirectory})).toBe(coverageDirectory);
+  });
+
+  it('findCoveragePath will return rootDir', () => {
+    const rootDir = 'COVERAGE_DIRECTORY';
+    expect(findCoveragePath({rootDir})).toBe(resolve(rootDir, 'coverage'));
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
-    "lib": [ "dom", "es6" ],
+    "target": "es2015",
+    "lib": [ "es2015" ],
     "removeComments": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
Jest requires a node engine of `>=6`; this means `es2015` in terms of node engines and tsconfig targets.