### PR TITLE
Ratchet coverage when set to zero

### DIFF
--- a/src/ratchet.ts
+++ b/src/ratchet.ts
@@ -41,11 +41,11 @@ const ratchetSingleNumberCoverage = (
   category: IstanbulCoverageCategory,
   options: RatchetOptions,
 ) => {
-  if (num && category) {
+  if (category && typeof num === 'number') {
     const tolerance = options.tolerance
       ? Math.round(category.pct) - options.tolerance
       : category.pct;
-    if (num > 0 && num <= tolerance) {
+    if (num >= 0 && num <= tolerance) {
       return options.roundDown ? Math.floor(tolerance) : tolerance;
     } else if (num < 0 && num >= -category.covered) {
       return -category.covered;

--- a/src/test.ts
+++ b/src/test.ts
@@ -68,6 +68,37 @@ describe('jest-ratchet', () => {
     });
   });
 
+  it('will ratchet coverage set to zero', () => {
+    const threshold = {
+      coverageThreshold: {
+        global: {
+          branches: 0,
+        },
+      },
+    };
+    setCoverageSummaryFile(fs, {
+      total: {
+        branches: {pct: 75},
+      },
+    });
+    setPackageJson(fs, { ...threshold });
+
+    const jestRatchet = new JestRatchet({
+      ...mockConfig,
+      ...threshold,
+      rootDir: './example',
+    });
+    jestRatchet.onRunComplete();
+
+    expectCoverageThreshold({
+      coverageThreshold: {
+        global: {
+          branches: 75,
+        },
+      },
+    });
+  });
+
   it('will ratchet non-global percentages', () => {
     const threshold = {
       coverageThreshold: {


### PR DESCRIPTION
As someone reported, if the coverage is set to zero in the jest config file or package.json then it won't update.  Any other value would work, but zero is ignored.