### PR TITLE
Only use latest version of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: node_js
 
 node_js:
   - "node"
-  - "6"
-  - "8"
-  - "10"
 
 env:
   - CXX=g++-4.8


### PR DESCRIPTION
With node versions updating more frequently and people staying up to date. I don't see as much of a reason to test older versions.  The latest version is fine.