### PR TITLE
Fix for Issue #92 - fs.watch Handler on Mac OS X Invoked Before Tests Complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "coverageReporters": [
       "json-summary",
       "lcovonly",
+      "text-summary",
       "html"
     ],
     "coverageThreshold": {


### PR DESCRIPTION
Tested out the suggested fix for issue #92. Had no issues on Mac OS 11.4