### PR TITLE
Added support for global max thresholds (Issue #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Coverage Status](https://coveralls.io/repos/github/markis/jest-ratchet/badge.svg?branch=master)](https://coveralls.io/github/markis/jest-ratchet?branch=master)
 [![Known Vulnerabilities](https://snyk.io/test/github/markis/jest-ratchet/badge.svg?targetFile=package.json)](https://snyk.io/test/github/markis/jest-ratchet?targetFile=package.json)
 
-
 Ratchet up code coverage - keep test coverage going only one direction -- up
 
 Jest-Ratchet is a coverage watcher for Jest. Everytime a new level of coverage is reached Jest-Ratchet will automatically update the coverageThreshold.
@@ -43,6 +42,7 @@ By default, Jest-Ratchet is aggressive with updating coverage thresholds. Every 
 - tolerance (number): keeps the threshold below the measured coverage, allowing wiggle room. default: 0 tolerance
 - roundDown (boolean): round down to the nearest integer. default: false
 - timeout (number): the number of milliseconds to wait for to the Jest coverage json summary. default: wait indefinitely
+- maxThresholds (object|number): the maximum value to ratchet all thresholds up to or each threshold can have a unique value. default: unbound
 
 Here's how to pass configuration to Jest-Ratchet, per the [Jest documentation](https://jestjs.io/docs/en/configuration.html#reporters-array-modulename-modulename-options)
 
@@ -52,9 +52,32 @@ Here's how to pass configuration to Jest-Ratchet, per the [Jest documentation](h
   "coverageReporters": ["json", "lcov", "text", "clover", "json-summary"],
   "reporters": [
     "default",
+    ["jest-ratchet", { "tolerance": 2, "roundDown": true, "timeout": 5000, "maxThresholds": 90 }]
+  ]
+}
+```
+
+Here is how to define different max thresholds for each jest threshold
+
+```json
+{
+  "collectCoverage": true,
+  "coverageReporters": ["json", "lcov", "text", "clover", "json-summary"],
+  "reporters": [
+    "default",
     [
       "jest-ratchet",
-      { "tolerance": 2, "roundDown": true, "timeout": 5000 }
+      {
+        "tolerance": 2,
+        "roundDown": true,
+        "timeout": 5000,
+        "maxThresholds": {
+          "branches": 80,
+          "lines": 75,
+          "functions": 90,
+          "statements": -100
+        }
+      }
     ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "coverageReporters": [
       "json-summary",
       "lcovonly",
-      "html"
+      "html",
+      "text-summary"
     ],
     "coverageThreshold": {
       "global": {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,10 +1,10 @@
-
 export interface IstanbulCoverage {
   total: IstanbulCoverageCategories;
   [fileName: string]: IstanbulCoverageCategories;
 }
 
 export interface IstanbulCoverageCategories {
+  [key: string]: IstanbulCoverageCategory;
   lines: IstanbulCoverageCategory;
   statements: IstanbulCoverageCategory;
   functions: IstanbulCoverageCategory;
@@ -12,7 +12,7 @@ export interface IstanbulCoverageCategories {
 }
 
 export interface IstanbulCoverageCategory {
-  total?: number;
+  total: number;
   covered: number;
   skipped?: number;
   pct: number;
@@ -24,6 +24,7 @@ export interface JestCoverage {
 }
 
 export interface JestCoverageCategory {
+  [key: string]: number | undefined;
   branches?: number;
   functions?: number;
   lines?: number;
@@ -39,6 +40,9 @@ export interface RatchetOptions {
 
   /** Round percentage thresholds down to the nearest integer. Default: false */
   roundDown?: boolean;
+
+  /** Maximum values to ratchet thresholds up to. Default: unbound */
+  maxThresholds?: JestCoverageCategory | number;
 }
 
 export interface Config {


### PR DESCRIPTION
This is to add support for setting max values that jest-ratchet will adjust the values to. Issue #7

Readme has been updated to reflect new capability.

Unit test have been added to cover all new code added/changed.

Also fixed bug with the negative values feature and now function properly along with being able to set max threshold using negative values.